### PR TITLE
Improvements to notch-finding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 __pycache__/
+.ipynb_checkpoints/

--- a/active_corners_grid.py
+++ b/active_corners_grid.py
@@ -30,14 +30,17 @@ def basic_safe_region_test(square, diamond, circle_traj):
     print(safe(diamond, circle_traj, Point(4, 0), Point(2, 0), x, y), True)
 
 
-def test_transitions(poly, trajectory, domain):
+def test_transitions(poly, trajectory, domain, x=None, y=None):
     angles, vertex_pairs = compute_polygon_angles(poly)
-    print(angles)
+    print("Angles:")
+    pprint(angles)
     dict_of_transitions, set_of_transitions = find_transitions(
         trajectory, angles, x, y, domain=domain
     )
-    print(set_of_transitions)
-    print(dict_of_transitions)
+    print("Set of transitions:")
+    pprint(set_of_transitions)
+    print("Dict of transitions:")
+    pprint(dict_of_transitions)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR mostly improves finding transition points for including notches. The main way it does so is by attempting to solve a different equation to identify the transition points. Previously, we solved the equation `slope = tan(angle)` but this led to issues when `angle = pi/2`. A better criteria (indeed a rearrangement that avoids division by 0) is `x1*y2 = x2*y1` where the two vectors are `[x1; y1], [x2, y2]`. In this case, one vector is the unit vector with angle theta: `[cos(theta); sin(theta)]` and the other is the two-dimensional gradient vector for `f(x,y) = 0`: `[df/dx, df/dy]`. 

Also fixes a ton of horrible variable names. 